### PR TITLE
Fix editor agent in default langgraph agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased Changes
 
+- Fix LangGraph agent `task_edit` to use the editor agent
+
 ## 11.2.4
 - Add support for streaming in agentic workflows
 - Add support for streaming to the agent:cli tools

--- a/agent_langgraph/custom_model/agent.py
+++ b/agent_langgraph/custom_model/agent.py
@@ -337,7 +337,7 @@ class MyAgent:
         )
 
     def task_edit(self, state: MessagesState) -> Command[Any]:
-        result = self.agent_planner.invoke(state)
+        result = self.agent_editor.invoke(state)
         result["messages"][-1] = HumanMessage(
             content=result["messages"][-1].content, name="editor_node"
         )


### PR DESCRIPTION
# Summary
Changes the agent used in `task_edit` from `self.agent_planner` to `self.agent_editor`.

# Rationale
This looks like a simple copy-paste bug, which leads to the agent outputting content plans rather than the final product.

# Checklist
- [x] Implementation
- [x] Update Changelog
- [ ] Manual run of API tests
- [x] Confirmed fix in a deployment
