### PR TITLE
DOC-9262: Add agent-to-agent documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ See the following documentation for more details:
 - [Use the agent CLI](https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-cli-guide.html)
 - [Add Python requirements](https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-python-packages.html)
 
-## Agent-to-agent
+## Agent2Agent
 
 Template agents can expose themselves as agent-to-agent (A2A) servers and connect to remote agents via the agent-to-agent protocol.
 
@@ -360,7 +360,7 @@ To connect an agent via A2A to a remote agent:
 - Uncomment the `function_groups` and `workflow.tool_names` blocks in the `workflow.yaml` file.
 - Run the agent with the experimental dragent front server: set `ENABLE_DRAGENT_SERVER=true` in your `.env` file.
 
-Enable **ENABLE_RUNTIME_PARAMETERS_IMPROVEMENTS** to use environment variables in the `workflow.yaml` files.
+Enable the **ENABLE_RUNTIME_PARAMETERS_IMPROVEMENTS** feature flag in DataRobot to use environment variables in the `workflow.yaml` files.
 
 ### Agent cards and DataRobot deployments
 
@@ -369,15 +369,6 @@ When the `ENABLE_GENAI_AGENT_TO_AGENT_SUPPORT` feature flag is enabled and you d
 - **List deployments with agent cards:** `GET deployments/?isA2AAgent=true`
 - **Retrieve an agent card:** `GET deployments/<deployment_id>/agentCard`
 
-Both API routes have corresponding methods in the Python client:
-
-```python
-deployments = dr.Deployment.list(filters=DeploymentListFilters(is_a2a_agent=True))
-agent_card = deployment.get_agent_card()
-# Only available for external deployments
-deployment.upload_agent_card(agent_card)
-deployment.delete_agent_card()
-```
 
 ### A2A agents hosted outside of DataRobot
 
@@ -389,6 +380,14 @@ For A2A agents hosted outside of DataRobot:
 
 For external deployments, you can also remove the agent card with `DELETE deployments/<deployment_id>/agentCard`.
 
+The API routes have corresponding methods in the Python client:
+
+```python
+deployments = dr.Deployment.list(filters=DeploymentListFilters(is_a2a_agent=True))
+agent_card = deployment.get_agent_card()
+# Only available for external deployments
+deployment.upload_agent_card(agent_card)
+deployment.delete_agent_card()
 # Get help
 
 If you encounter issues or have questions, try the following:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ They support local development and testing, as well as deployment to production 
 - [Installation](#installation)
 - [Create and deploy your agent](#create-and-deploy-your-agent)
 - [Develop your agent](#develop-your-agent)
+- [Agent-to-agent](#agent-to-agent)
 - [Get help](#get-help)
 
 ---
@@ -344,6 +345,49 @@ See the following documentation for more details:
 - [Configure LLM providers](https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-llm-providers.html)
 - [Use the agent CLI](https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-cli-guide.html)
 - [Add Python requirements](https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-python-packages.html)
+
+## Agent-to-agent
+
+Template agents can expose themselves as agent-to-agent (A2A) servers and connect to remote agents via the agent-to-agent protocol.
+
+To expose an agent via A2A:
+
+- Templates must have a `general.front_end.a2a` configuration block. By default, templates already include this.
+- Run the agent with the experimental dragent front server: set `ENABLE_DRAGENT_SERVER=true` in your `.env` file.
+
+To connect an agent via A2A to a remote agent:
+
+- Uncomment the `function_groups` and `workflow.tool_names` blocks in the `workflow.yaml` file.
+- Run the agent with the experimental dragent front server: set `ENABLE_DRAGENT_SERVER=true` in your `.env` file.
+
+Enable **ENABLE_RUNTIME_PARAMETERS_IMPROVEMENTS** to use environment variables in the `workflow.yaml` files.
+
+### Agent cards and DataRobot deployments
+
+When the `ENABLE_GENAI_AGENT_TO_AGENT_SUPPORT` feature flag is enabled and you deploy an agent that exposes A2A server endpoints, the agent card for that agent is stored in DataRobot during deployment. Use the following endpoints:
+
+- **List deployments with agent cards:** `GET deployments/?isA2AAgent=true`
+- **Retrieve an agent card:** `GET deployments/<deployment_id>/agentCard`
+
+Both API routes have corresponding methods in the Python client:
+
+```python
+deployments = dr.Deployment.list(filters=DeploymentListFilters(is_a2a_agent=True))
+agent_card = deployment.get_agent_card()
+# Only available for external deployments
+deployment.upload_agent_card(agent_card)
+deployment.delete_agent_card()
+```
+
+### A2A agents hosted outside of DataRobot
+
+For A2A agents hosted outside of DataRobot:
+
+1. Create an external model.
+2. Deploy the external model.
+3. Push the agent card via `PUT deployments/<deployment_id>/agentCard`.
+
+For external deployments, you can also remove the agent card with `DELETE deployments/<deployment_id>/agentCard`.
 
 # Get help
 


### PR DESCRIPTION
# Summary

Adding instructions for configuring agent-to-agent support.

# Rationale

# Checklist
- [ ] Implementation
- [ ] Update Changelog
- [x] Manual run of API tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is potential README markdown formatting issues (e.g., missing code-block termination) affecting rendered docs.
> 
> **Overview**
> Adds an **Agent-to-agent (A2A)** section to `README.md` describing how to run template agents as A2A servers and connect to remote A2A agents, including required config blocks, `ENABLE_DRAGENT_SERVER`, and workflow.yaml toggles.
> 
> Documents how agent cards are stored/retrieved for DataRobot deployments (feature-flag gated), the REST endpoints for listing/retrieving/uploading/deleting agent cards (including external deployments), and the corresponding Python client methods; updates the table of contents to link to this new section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 896e7df0c40ad743e3ddef2ccac75160b2d974c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->